### PR TITLE
main: add support for parsing file URIs

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"github.com/caarlos0/spin"
-	"github.com/logrusorgru/aurora"
 	"gopkg.in/cheggaaa/pb.v1"
 	"os"
 	"path/filepath"
@@ -23,25 +22,25 @@ func main() {
 	s := state{step: 0, total: 0, sent: 0}
 
 	if len(args) != 1 {
-		fmt.Println(aurora.Blue("Usage: wally-cli <firmware file>"))
+		fmt.Println("Usage: wally-cli <firmware file>")
 		os.Exit(2)
 	}
 
 	if args[0] == "--version" {
 		appVersion := fmt.Sprintf("wally-cli v%s", appVersion)
-		fmt.Println(aurora.Blue(appVersion))
+		fmt.Println(appVersion)
 		os.Exit(0)
 	}
 
 	path := args[0]
 	extension := filepath.Ext(path)
 	if extension != ".bin" && extension != ".hex" {
-		fmt.Println(aurora.Red("Please provide a valid firmware file: a"), aurora.Red(aurora.Underline(".hex")), aurora.Red("file (ErgoDox EZ) or a"), aurora.Red(aurora.Underline(".bin")), aurora.Red("file (Moonlander / Planck EZ)"))
+		fmt.Println("Please provide a valid firmware file: a .hex file (ErgoDox EZ) or a .bin file (Moonlander / Planck EZ)")
 		os.Exit(2)
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		fmt.Println(aurora.Red("The file path you specified does not exist"))
+		fmt.Println("The file path you specified does not exist")
 		os.Exit(1)
 	}
 
@@ -74,5 +73,5 @@ func main() {
 		}
 	}
 	progress.Finish()
-	fmt.Println(aurora.Green("Your keyboard was successfully flashed and rebooted. Enjoy the new firmware!"))
+	fmt.Println("Your keyboard was successfully flashed and rebooted. Enjoy the new firmware!")
 }

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		fmt.Println("The file path you specified does not exist")
+		fmt.Println("The file path you specified does not exist:", path)
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	if len(args) != 1 {
 		fmt.Println(aurora.Blue("Usage: wally-cli <firmware file>"))
-		os.Exit(0)
+		os.Exit(2)
 	}
 
 	if args[0] == "--version" {
@@ -34,14 +34,14 @@ func main() {
 	}
 
 	path := args[0]
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		fmt.Println(aurora.Red("The file path you specified does not exist"))
-		os.Exit(1)
-	}
-
 	extension := filepath.Ext(path)
 	if extension != ".bin" && extension != ".hex" {
 		fmt.Println(aurora.Red("Please provide a valid firmware file: a"), aurora.Red(aurora.Underline(".hex")), aurora.Red("file (ErgoDox EZ) or a"), aurora.Red(aurora.Underline(".bin")), aurora.Red("file (Moonlander / Planck EZ)"))
+		os.Exit(2)
+	}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		fmt.Println(aurora.Red("The file path you specified does not exist"))
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/caarlos0/spin"
-	"gopkg.in/cheggaaa/pb.v1"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/caarlos0/spin"
+	"gopkg.in/cheggaaa/pb.v1"
 )
 
 var appVersion = "2.0.0"
@@ -36,9 +38,20 @@ func main() {
 		os.Exit(2)
 	}
 
-	path := flag.Arg(0)
-	extension := filepath.Ext(path)
-	if extension != ".bin" && extension != ".hex" {
+	path := ""
+	extension := ""
+	if uri, err := url.Parse(flag.Arg(0)); err == nil {
+		switch uri.Scheme {
+		case "", "file":
+			extension = filepath.Ext(uri.Path)
+			switch extension {
+			case ".bin", ".hex":
+				path = uri.Path
+			}
+		}
+	}
+
+	if path == "" {
 		fmt.Println("Please provide a valid firmware file: a .hex file (ErgoDox EZ) or a .bin file (Moonlander / Planck EZ)")
 		os.Exit(2)
 	}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/caarlos0/spin"
 	"gopkg.in/cheggaaa/pb.v1"
@@ -18,21 +19,24 @@ type state struct {
 }
 
 func main() {
-	var args = os.Args[1:]
-	s := state{step: 0, total: 0, sent: 0}
-
-	if len(args) != 1 {
-		fmt.Println("Usage: wally-cli <firmware file>")
-		os.Exit(2)
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s: [flags] <firmware file>\n", os.Args[0])
+		flag.PrintDefaults()
 	}
+	version := flag.Bool("version", false, "print the version and exit")
+	flag.Parse()
 
-	if args[0] == "--version" {
-		appVersion := fmt.Sprintf("wally-cli v%s", appVersion)
-		fmt.Println(appVersion)
+	if *version {
+		fmt.Println(fmt.Sprintf("wally-cli v%s", appVersion))
 		os.Exit(0)
 	}
 
-	path := args[0]
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	path := flag.Arg(0)
 	extension := filepath.Ext(path)
 	if extension != ".bin" && extension != ".hex" {
 		fmt.Println("Please provide a valid firmware file: a .hex file (ErgoDox EZ) or a .bin file (Moonlander / Planck EZ)")
@@ -51,6 +55,7 @@ func main() {
 	var progress *pb.ProgressBar
 	progressStarted := false
 
+	s := state{step: 0, total: 0, sent: 0}
 	if extension == ".bin" {
 		go dfuFlash(path, &s)
 	}


### PR DESCRIPTION
This is helpful if you want to configure Firefox to automatically run
wally when downloading a firmware image.

Is this too reckless? I haven't tried flashing the wrong firmware to my keyboard (yet).

This builds on https://github.com/zsa/wally-cli/pull/4.