### PR TITLE
Replace caarlos0/spin with briandowns/spinner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/zsa/wally-cli
 go 1.14
 
 require (
-	github.com/caarlos0/spin v1.1.0
+	github.com/briandowns/spinner v1.12.0
 	github.com/google/gousb v2.1.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/marcinbor85/gohex v0.0.0-20200531163658-baab2527a9a2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/caarlos0/spin v1.1.0 h1:EjsfGbZJejib25BPnDqf7iL2z9RUna7refvUf+AN9UE=
-github.com/caarlos0/spin v1.1.0/go.mod h1:HOC4pUvfhjXR2yDt+sEY9dRc2m4CCaK5z5oQYAbzXSA=
+github.com/briandowns/spinner v1.12.0 h1:72O0PzqGJb6G3KgrcIOtL/JAGGZ5ptOMCn9cUHmqsmw=
+github.com/briandowns/spinner v1.12.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/google/gousb v1.1.0 h1:s/970WE1z968MC+dtWbuxDHCcx9kwANQo6UcZtfTfx0=
 github.com/google/gousb v2.1.0+incompatible h1:ApzMDjF3FeO219QwWybJxYfFhXQzPLOEy0o+w9k5DNI=
 github.com/google/gousb v2.1.0+incompatible/go.mod h1:Tl4HdAs1ThE3gECkNwz+1MWicX6FXddhJEw7L8jRDiI=
@@ -7,8 +9,13 @@ github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczG
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/marcinbor85/gohex v0.0.0-20200531163658-baab2527a9a2 h1:n7R8fUwWZUB2XtyzBNsYNNm9/XgOBj6pvLi7GLMCHtM=
 github.com/marcinbor85/gohex v0.0.0-20200531163658-baab2527a9a2/go.mod h1:Pb6XcsXyropB9LNHhnqaknG/vEwYztLkQzVCHv8sQ3M=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/cheggaaa/pb.v1 v1.0.28 h1:n1tBJnnK2r7g9OW2btFH91V92STTUevLXYFb8gy9EMk=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/caarlos0/spin"
+	"github.com/briandowns/spinner"
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
@@ -61,8 +61,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	spinner := spin.New("%s Press the reset button of your keyboard.")
-	spinner.Start()
+	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	spin.Suffix = " Press the reset button of your keyboard."
+	spin.Color("black")
+	spin.Start()
 	spinnerStopped := false
 
 	var progress *pb.ProgressBar
@@ -80,7 +82,7 @@ func main() {
 		time.Sleep(500 * time.Millisecond)
 		if s.step > 0 {
 			if spinnerStopped == false {
-				spinner.Stop()
+				spin.Stop()
 				spinnerStopped = true
 			}
 			if progressStarted == false {


### PR DESCRIPTION
Hi!
Wally-cli depends on [spin](https://github.com/caarlos0-graveyard/spin ) which is not free software (there is no license in the repo, no file contain a license header, opened an issue [here](https://github.com/caarlos0-graveyard/spin/issues/8)).

Would it be possible to remove the dependency (either by replacing it with another package or by dropping the spinner)?

This PR is just an example (first result for spinner under https://pkg.go.dev), and has the downside of introducing more dependencies (and probably the color is wrong). I'll look for another with no dependencies if the idea to replace this is ok

Let me know, thanks!