### PR TITLE
Add Nix build files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import <nixpkgs> {}), lib ? (import <nixpkgs/lib>), system ? builtins.currentSystem }:
+{ pkgs ? (import <nixpkgs> { }), lib ? (import <nixpkgs/lib>), system ? builtins.currentSystem }:
 
 assert lib.versionAtLeast pkgs.go.version "1.14";
 
@@ -11,7 +11,7 @@ pkgs.buildGoModule rec {
   vendorSha256 = "HffgkuKmaOjTYi+jQ6vBlC50JqqbYiikURT6TCqL7e0=";
 
   subPackages = [ "." ];
- 
+
   buildInputs = with pkgs; [ libusb1 ];
   nativeBuildInputs = with pkgs; [ pkg-config ];
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+{ pkgs ? (import <nixpkgs> {}), lib ? (import <nixpkgs/lib>), system ? builtins.currentSystem }:
+
+assert lib.versionAtLeast pkgs.go.version "1.14";
+
+pkgs.buildGoModule rec {
+  name = "wally-cli";
+  version = "v2.0.0";
+
+  src = ./.;
+
+  vendorSha256 = "HffgkuKmaOjTYi+jQ6vBlC50JqqbYiikURT6TCqL7e0=";
+
+  subPackages = [ "." ];
+ 
+  buildInputs = with pkgs; [ libusb1 ];
+  nativeBuildInputs = with pkgs; [ pkg-config ];
+
+  meta = with lib; {
+    description = "Flash your ZSA Keyboard the EZ way.";
+    homepage = "https://github.com/zsa/wally-cli";
+    license = licenses.mit;
+    maintainers = [ johnrichardrinehart ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1620808985,
+        "narHash": "sha256-cf/+g1RVawT0rcKmfh2nf/lgnSrj9YZS+1PkCFmoeJQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "327368f98c6a927a84aed3c2f2fd1a7f6983e855",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-20.09",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs/release-20.09";
+		flake-utils.url = "github:numtide/flake-utils";
+	};
+
+
+	outputs = inputs: 
+	let
+		inherit (inputs.flake-utils.lib) eachDefaultSystem flattenTree mkApp;
+	in
+	eachDefaultSystem (system:
+      let
+	 	pkgs = inputs.nixpkgs.legacyPackages.${system};
+	  	lib = inputs.nixpkgs.lib;
+	  in
+      rec {
+        defaultPackage = (import ./default.nix) {
+			inherit pkgs lib system;
+		};
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,25 +1,25 @@
 {
-	inputs = {
-		nixpkgs.url = "github:nixos/nixpkgs/release-20.09";
-		flake-utils.url = "github:numtide/flake-utils";
-	};
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/release-20.09";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
 
 
-	outputs = inputs: 
-	let
-		inherit (inputs.flake-utils.lib) eachDefaultSystem flattenTree mkApp;
-	in
-	eachDefaultSystem (system:
+  outputs = inputs:
+    let
+      inherit (inputs.flake-utils.lib) eachDefaultSystem flattenTree mkApp;
+    in
+    eachDefaultSystem (system:
       let
-	 	pkgs = inputs.nixpkgs.legacyPackages.${system};
-	  	lib = inputs.nixpkgs.lib;
-	  in
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+        lib = inputs.nixpkgs.lib;
+      in
       rec {
         defaultPackage = (import ./default.nix) {
-			inherit pkgs lib system;
-		};
+          inherit pkgs lib system;
+        };
 
-		defaultApp = defaultPackage;
+        defaultApp = defaultPackage;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
         defaultPackage = (import ./default.nix) {
 			inherit pkgs lib system;
 		};
+
+		defaultApp = defaultPackage;
       }
     );
 }


### PR DESCRIPTION
# Summary

This PR introduces a few files that help `Nix`/`NixOS` users build and use `wally-cli`.

To build with flakes, ensure experimental support for flakes [is enabled](https://nixos.wiki/wiki/Flakes) and `nix build` from the root of the repository.

To build without flakes (`default.nix`) execute `nix-build` from the root of the repository.

After building `wally-cli` should be available at `./result/bin/wally-cli`.