### PR TITLE
Add install command for go >= 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Note for Mac OS users, the CLI requires libusb to be installed: `brew install li
 
 You can also compile and install Wally using go's package manager, make sure you follow the `Installing dev dependencies` section for your platform below:
 
+For go >= 1.17
+```
+go install github.com/zsa/wally-cli@latest
+```
+For go < 1.17
 ```
 go get -u github.com/zsa/wally-cli
 ```


### PR DESCRIPTION
go get outside of a module was deprecated at 1.17 and doesn't work on 1.18 anymore