### PR TITLE
Update Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note for Mac OS users, the CLI requires libusb to be installed: `brew install li
 You can also compile and install Wally using go's package manager, make sure you follow the `Installing dev dependencies` section for your platform below:
 
 ```
-go get -u github.com/zsa/wally-cli
+go install github.com/zsa/wally-cli@latest
 ```
 
 Note: Raspberry pi users using the 32bit version of raspbian should run


### PR DESCRIPTION
Go packages are now installed with `go install` as of go 1.17:

```shell
~/dev ☿ go get -u github.com/zsa/wally-cli                      
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

~/dev[1:ERROR] ☿ go install github.com/zsa/wally-cli@latest
go: downloading github.com/zsa/wally-cli v0.0.0-20221021113736-b0fafe52cc7f
go: downloading github.com/briandowns/spinner v1.18.0
go: downloading github.com/marcinbor85/gohex v0.0.0-20200531163658-baab2527a9a2
go: downloading github.com/google/gousb v2.1.0+incompatible
go: downloading gopkg.in/cheggaaa/pb.v1 v1.0.28
go: downloading golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d
go: downloading github.com/fatih/color v1.7.0
go: downloading github.com/mattn/go-colorable v0.1.2
go: downloading github.com/mattn/go-isatty v0.0.8

~/dev ☿ wally-cli --version                 
wally-cli v2.0.1
```

I don't have a raspberry pi handy, so can't confirm the same works for there.